### PR TITLE
Strip whitespace surrounding colon

### DIFF
--- a/src/includes/classes/Core.php
+++ b/src/includes/classes/Core.php
@@ -96,6 +96,7 @@ class Core
                 ';',
                 ',',
                 '>',
+                ':',
             );
             $de_spacifiables = array_map(
                 function ($string) {


### PR DESCRIPTION
Turns

``` css
background-color: #FFFFFF; font-size: 14px;
```

into

``` css
background-color:#FFF;font-size:14px;
```

Note the missing spaces after `:`
